### PR TITLE
引数の型警告修正対応

### DIFF
--- a/src/sipf/sipf_client_http.c
+++ b/src/sipf/sipf_client_http.c
@@ -28,7 +28,7 @@ static uint8_t res_buff[BUFF_SZ];
 static char req_auth_header[256];
 
 /* Setup TLS options on a given socket */
-static int tls_setup(int fd, char *host_name)
+static int tls_setup(int fd, const char *host_name)
 {
   int err;
   int verify;


### PR DESCRIPTION
tls_setupのhostname引数はconstで良いのでconstにすることで対応。

```
../src/sipf/sipf_client_http.c: In function 'run_http_request':
../src/sipf/sipf_client_http.c:135:25: warning: passing argument 2 of 'tls_setup' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  135 |   ret = tls_setup(sock, hostname);
      |                         ^~~~~~~~
../src/sipf/sipf_client_http.c:31:36: note: expected 'char *' but argument is of type 'const char *'
   31 | static int tls_setup(int fd, char *host_name)
      |                              ~~~~~~^~~~~~~~~
```