### PR TITLE
uart_broker.hに必要なincludeを追加

### DIFF
--- a/include/uart_broker.h
+++ b/include/uart_broker.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include <drivers/uart.h>
+
 #define UART_LABEL DT_LABEL(DT_NODELABEL(uart0))
 
 #define UART_TX_BUF_SZ (256)


### PR DESCRIPTION
`uart_broker.h` の解釈に `drivers/uart.h` が必要だったためincludeを追加。


### 対応する警告

```
[38/230] Building C object CMakeFiles/app.dir/src/fota/fota_http.c.obj
In file included from ../src/fota/fota_http.c:11:
../include/uart_broker.h:17:33: warning: 'struct device' declared inside parameter list will not be visible outside of this definition or declaration
   17 | int UartBrokerInit(const struct device *uart);
      |                   
```